### PR TITLE
Add new MIPS SoC: Kirin / MSD7T75

### DIFF
--- a/index.md
+++ b/index.md
@@ -211,6 +211,10 @@ ones.
 - [MSD7T01](kriti#msd7t01) - 576 MHz MIPS 34Kf + 64 MiB DDR2 in a eLQFP128
 - [MSD7T03](kriti#msd7t03) - same as MSD7T01 but with 128 MiB DDR3 instead
 
+### [Kirin](kirin)
+
+- [MSD7T75](kirin#msd7t75) - 1000 MHz(?) MIPS 74Kf
+
 ### K5AP
 
 - MSA7T00 - 750 MHz MIPS 34Kf + 64 MiB DDR2 in a QFN80

--- a/ip/intc.md
+++ b/ip/intc.md
@@ -1,5 +1,7 @@
 # non-pm interrupt controllers
 
+## ARM
+
 According to a developer at MediaTek this is the same IP as is in some MediaTek chips.
 See this [thread](https://lore.kernel.org/linux-arm-kernel/654a81dcefb3024d762ff338d4bd7f14@kernel.org/T/#m9afc5a57195be881661dcf6ea77a1e299f36d9f6).
 
@@ -48,3 +50,24 @@ See this [thread](https://lore.kernel.org/linux-arm-kernel/654a81dcefb3024d762ff
  * 0x2c
  */
 ```
+
+
+## MIPS
+
+On MIPS platforms, the interupt controller is instanciated twice:
+
+- at 0xbf203340, connected to CPU interrupt 2; ACK/EOI writes are not needed
+- at 0xbf203300, connected to CPU interrupt 3; ACK/EOI writes are needed
+
+Register map:
+
+| RIU     | phys  | description                                                |
+|---------|-------|------------------------------------------------------------|
+| 0x08    | 0x10  | interrupt mask, 0=allow, 1=block (0..15)                   |
+| 0x0a    | 0x14  | interrupt mask, 0=allow, 1=block (16..31)                  |
+| 0x0c    | 0x18  | interrupt mask, 0=allow, 1=block (32..47)                  |
+| 0x0e    | 0x1c  | interrupt mask, 0=allow, 1=block (48..63)                  |
+| 0x18    | 0x30  | interrupt status, write 1 to ACK (0..15)                   |
+| 0x1a    | 0x34  | interrupt status, write 1 to ACK (16..31)                  |
+| 0x1c    | 0x38  | interrupt status, write 1 to ACK (32..47)                  |
+| 0x1e    | 0x3c  | interrupt status, write 1 to ACK (48..63)                  |

--- a/kirin/index.md
+++ b/kirin/index.md
@@ -1,0 +1,11 @@
+# Kirin
+
+## Specs
+
+- MIPS 74Kf
+
+[Pinouts](pinouts.md) | [RIU map](riu-map.md) | [Interrupt map](int-map.md)
+
+## MSD7T75
+
+- Chip ID: 0x98

--- a/kirin/int-map.md
+++ b/kirin/int-map.md
@@ -1,0 +1,47 @@
+# Kirin Interrupt map
+
+## MIPS CPU intc
+
+Eight interrupt lines are directly attached to the CPU, mediated by the IM0..7 bits in the `Status` register.[^1]
+
+| line | description                                                    |
+|------|----------------------------------------------------------------|
+|  0   | software interrupt                                             |
+|  1   | software interrupt                                             |
+|  2   | non-PM interrupt controller 0 ([0xbf203340]), no EOI           |
+|  3   | non-PM interrupt controller 1 (0xbf203300)                     |
+|  4   |                                                                |
+|  5   |                                                                |
+|  6   |                                                                |
+|  7   | timer interrupt                                                |
+
+[^1]: MIPS® Architecture For Programmers Vol. III: MIPS32®/microMIPS32™ Privileged Resource Architecture, chapter 9.32 Status Register
+
+[0xbf203340]: ../ip/intc.md#mips
+
+## Non-PM intc 0
+
+| line |        name        |    notes                                  |
+|------|--------------------|-------------------------------------------|
+|   0  | UART0              |                                           |
+|   3  | MVD                |                                           |
+|   9  | EMAC               |                                           |
+|  10  | XC                 |                                           |
+|  22  | HDMITX             |                                           |
+|  25  | GPD                |                                           |
+|  39  | SC                 |                                           |
+|  45  | JPD                |                                           |
+
+## Non-PM intc 1
+
+| line |        name        |    notes                                  |
+|------|--------------------|-------------------------------------------|
+|   4  | MAILBOX            |                                           |
+|  13  | MAILBOX            |                                           |
+|  14  | AUDIO              |                                           |
+|  24  | CIPHER             |                                           |
+|  26  | XC                 |                                           |
+|  27  | IR                 |                                           |
+|  29  | AUDIO              |                                           |
+|  37  | MAILBOX            |                                           |
+|  38  | MAILBOX            |                                           |

--- a/kirin/riu-map.md
+++ b/kirin/riu-map.md
@@ -1,0 +1,30 @@
+# Kirin RIU map
+
+## PM
+
+| riu addr |  phy addr  |             name              |
+|----------|------------|-------------------------------|
+| 0x000800 | 0x1f001000 | SERFLASH                      |
+| 0x000e00 | 0x1f001c00 |                               |
+| 0x001600 | 0x1f002c00 | FSP                           |
+| 0x001e00 | 0x1f003c00 | PM_TOP                        |
+| 0x003100 | 0x1f006200 | EPHY (MDIO)                   |
+| 0x003200 | 0x1f006400 | ethernet related?             |
+| 0x003300 | 0x1f006600 | ethernet related?             |
+| 0x003c00 | 0x1f007800 | SERFLASH DMA                  |
+
+## Non-PM
+
+| riu addr |  phy addr  |             name              |
+|----------|------------|-------------------------------|
+| 0x100900 | 0x1f201200 | BDMA                          |
+| 0x100980 | 0x1f201300 | UART0                         |
+| 0x101900 | 0x1f203200 | INTR_CTRL                     |
+| 0x101e00 | 0x1f203c00 | pad mux                       |
+| 0x102500 | 0x1f204a00 | GPIO                          |
+| 0x103300 | 0x1f206600 | ethernet related?             |
+| 0x111500 | 0x1f222a00 | AUDSP                         |
+| 0x111600 | 0x1f222c00 | AUDSP                         |
+| 0x121b00 | 0x1f243600 | EMAC                          |
+| 0x121f00 | 0x1f243e00 | ethernet related?             |
+| 0x160300 | 0x1f2c0600 | AUDSP top                     |


### PR DESCRIPTION
This adds some rudimentary information about the MSD7T75 SoC which I've been toying with, along with some information about the interrupt controller as used in MIPS SoCs.

Please tell me if I should split/edit/remove something, this is really just a first draft that I wanted to get out the door.